### PR TITLE
Migration add reason

### DIFF
--- a/infra/migrations/1750803901101_alter-table-content-tabcoin-operations-add-column-reason.js
+++ b/infra/migrations/1750803901101_alter-table-content-tabcoin-operations-add-column-reason.js
@@ -1,0 +1,10 @@
+exports.up = (pgm) => {
+  pgm.addColumns('content_tabcoin_operations', {
+    reason: {
+      type: 'varchar(255)',
+      notNull: false,
+    },
+  });
+};
+
+exports.down = false;

--- a/models/balance.js
+++ b/models/balance.js
@@ -92,7 +92,7 @@ async function getContentTabcoinsCreditDebit({ recipientId }, options = {}) {
   };
 }
 
-async function rateContent({ contentId, contentOwnerId, fromUserId, transactionType }, options = {}) {
+async function rateContent({ contentId, contentOwnerId, fromUserId, transactionType, reason = null }, options = {}) {
   const tabCoinsToDebitFromUser = -2;
   const tabCashToCreditToUser = 1;
   const tabCoinsToTransactToContentOwner = transactionType === 'credit' ? 1 : -1;
@@ -119,9 +119,9 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
       ),
       content_insert AS (
         INSERT INTO content_tabcoin_operations
-          (balance_type, recipient_id, amount, originator_type, originator_id)
+          (balance_type, recipient_id, amount, originator_type, originator_id, reason)
         VALUES
-          ($10, $4, $5, 'user', $1)
+          ($10, $4, $5, 'user', $1, $11)
         RETURNING
           *
       )
@@ -129,7 +129,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
         get_user_current_tabcoins($1) AS user_current_tabcoin_balance,
         tabcoins_count.total_balance as content_current_tabcoin_balance,
         tabcoins_count.total_credit as content_current_tabcoin_credit,
-        tabcoins_count.total_debit as content_current_tabcoin_debit 
+        tabcoins_count.total_debit as content_current_tabcoin_debit
       FROM
         users_tabcoin_inserts,
         content_insert,
@@ -152,6 +152,8 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
       originatorId, // $9
 
       transactionType, // $10
+
+      reason, // $11
     ],
   };
 


### PR DESCRIPTION
# Mudanças realizadas
1. Criação da migration para adicionar nova coluna `reason` na tabela `content_tabcoin_operations`
2. Inclusão do parâmetro `reason` com o valor default `null` no método `rateContent` na model `balance`