### PR TITLE
Test read file error

### DIFF
--- a/tests/unit/models/user.test.ts
+++ b/tests/unit/models/user.test.ts
@@ -54,5 +54,15 @@ describe('User Model', () => {
       );
       expect(result).toStrictEqual(mockUpdatedUser);
     });
+
+    it('should throw an error if fs.readFile fails', async () => {
+      const targetUser = { id: 'user-id-123' };
+      const postedUserData = { avatar: { filepath: '/tmp/file.png' } };
+
+      vi.mocked(validator).mockReturnValue({ avatar: postedUserData.avatar });
+      vi.mocked(fs.readFile).mockRejectedValue(new Error('Failed to read file'));
+
+      await expect(user.updateAvatar(targetUser, postedUserData)).rejects.toThrow('Failed to read file');
+    });
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

1. Teste unitário para a função `updateAvatar` no model de usuário, cobrindo o cenário em que a leitura do arquivo de avatar falha.
