### PR TITLE
Test update avatar

### DIFF
--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -5,7 +5,7 @@ import logger from 'infra/logger';
 
 export default function customRemoveMarkdown(md, options = {}) {
   options.oneLine = Object.hasOwn(options, 'oneLine') ? options.oneLine : true;
-  options.throwError = Object.hasOwn(options, 'logError') ? options.throwError : true;
+  options.throwError = Object.hasOwn(options, 'throwError') ? options.throwError : true;
   options.trim = Object.hasOwn(options, 'trim') ? options.trim : true;
 
   let output = md || '';

--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -5,7 +5,7 @@ import logger from 'infra/logger';
 
 export default function customRemoveMarkdown(md, options = {}) {
   options.oneLine = Object.hasOwn(options, 'oneLine') ? options.oneLine : true;
-  options.throwError = Object.hasOwn(options, 'throwError') ? options.throwError : true;
+  options.logError = Object.hasOwn(options, 'logError') ? options.logError : true;
   options.trim = Object.hasOwn(options, 'trim') ? options.trim : true;
 
   let output = md || '';
@@ -24,7 +24,7 @@ export default function customRemoveMarkdown(md, options = {}) {
 
     output = truncate(output, options.maxLength);
   } catch (e) {
-    if (options.throwError) {
+    if (options.logError) {
       logger.error(e);
     }
 

--- a/tests/unit/models/user.test.ts
+++ b/tests/unit/models/user.test.ts
@@ -54,5 +54,39 @@ describe('User Model', () => {
       );
       expect(result).toStrictEqual(mockUpdatedUser);
     });
+
+    it('should replace the existing avatar with a new one', async () => {
+      const mockUploadResponse = {
+        cid: 'fake-cid',
+        id: 'fake-id',
+        name: 'avatar.png',
+        size: 123456,
+        type: 'image/png',
+        created_at: new Date().toISOString(),
+        number_of_files: 1,
+        mime_type: 'image/png',
+        group_id: 'group-123',
+        keyvalues: {},
+        sha256: 'hash123',
+        path: '/tmp/avatar.png',
+        vectorized: false,
+        network: 'ipfs',
+      };
+
+      const previousAvatarUrl = 'https://example.com/old-avatar.png';
+      const targetUser = { id: 'user-id-123', avatar_url: previousAvatarUrl };
+      const postedUserData = { avatar: { filepath: '/tmp/new-avatar.png' } };
+      const newAvatarUrl = 'https://example.com/new-avatar.png';
+
+      vi.mocked(validator).mockReturnValue({ avatar: postedUserData.avatar });
+      vi.mocked(fs.readFile).mockResolvedValue(Buffer.from(''));
+      vi.mocked(storage.upload.public.file).mockResolvedValue(mockUploadResponse);
+      vi.mocked(storage.gateways.public.convert).mockResolvedValue(newAvatarUrl);
+      vi.mocked(database.query).mockResolvedValue({ rows: [{ id: targetUser.id, avatar_url: newAvatarUrl }] });
+
+      const result = await user.updateAvatar(targetUser, postedUserData);
+      expect(result.avatar_url).toBe(newAvatarUrl);
+      expect(result.avatar_url).not.toBe(previousAvatarUrl);
+    });
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

1. Teste unitário que quando um usuário com avatar previamente definido realiza o envio de uma nova imagem, o campo `avatar_url` do usuário seja corretamente atualizado com a nova URL gerada após o upload. Essa, substitua a anterior.